### PR TITLE
Also depend on gobject-2.0

### DIFF
--- a/glib-stopgap.cabal
+++ b/glib-stopgap.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -41,6 +41,7 @@ library
       src
   pkgconfig-depends:
       glib-2.0
+    , gobject-2.0
   build-depends:
       base >=4.7 && <5
     , c-enum

--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,9 @@ dependencies:
 
 library:
   source-dirs: src
-  pkg-config-dependencies: glib-2.0
+  pkg-config-dependencies:
+  - glib-2.0
+  - gobject-2.0
 
 tests:
   glib-stopgap-test:


### PR DESCRIPTION
glib-stopgap uses g_object_unref which is provided by gobject, so it also needs to depend on it as well. Apparently, gobject is propagated from glib for some versions of glib, but we can't rely on this in all versions.